### PR TITLE
Feature/travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,16 @@ sudo: required
 
 language: python
 
+python: "3.6"
+
 services:
-  - docker
+  - postgres
 
-before_install:
-  - docker-compose build
-
-install:
-  - pip install coveralls
+addons:
+  postgresql: "9.6"
 
 script:
-  - docker-compose run app test
+  - coverage run --source='.' manage.py test --settings=stuart_is.settings.test
 
 after_success:
-  - sed -i "s~/usr/src/application~$TRAVIS_BUILD_DIR~g" .coverage
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+dist: trusty
 sudo: required
 
 language: python
-
 python: "3.6"
 
 services:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psycopg2==2.7.1
 # Testing
 flake8==3.3.0
 coverage==4.4.1
+coveralls==1.1

--- a/stuart_is/settings/base.py
+++ b/stuart_is/settings/base.py
@@ -76,7 +76,6 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'postgres',
         'USER': 'postgres',
-        'HOST': 'db',  # docker-compose service hostname
     }
 }
 


### PR DESCRIPTION
Using Docker on Travis CI has feels like we’re swimming against the current. Instead, we’ll use native PostgreSQL (rather than Dockerised version).

- updates Travis CI settings to use native env, not Docker
- updates database connection settings